### PR TITLE
Weighted-time difficulty adjustment

### DIFF
--- a/mining.py
+++ b/mining.py
@@ -213,6 +213,19 @@ def next_bits_cw(msg, block_count):
     interval_target = compute_cw_target(block_count)
     return target_to_bits(interval_target)
 
+def next_bits_wt(msg, block_count):
+    first, last  = -1-block_count, -1
+    last_target = bits_to_target(states[last].bits)
+    timespan = 0
+    for i in range(last, first, -1):
+        target_i = bits_to_target(states[i].bits)
+        time_i = states[i].timestamp - states[i-1].timestamp
+        adj_time_i = time_i * target_i // last_target
+        timespan += adj_time_i * 2 * (i - first) // block_count
+    target = last_target * timespan
+    target //= 600 * block_count
+    return target_to_bits(target)
+
 def block_time(mean_time):
     # Sample the exponential distn
     sample = random.random()
@@ -303,6 +316,9 @@ Algos = {
     }),
     'cw-180' : Algo(next_bits_cw, {
         'block_count': 180,
+    }),
+    'wt-144' : Algo(next_bits_wt, {
+        'block_count': 144,
     }),
 }
 


### PR DESCRIPTION
Algo ID: wt-144

To facilitate faster continuous retargeting, two weights are applied to the individual inter-block times within a sliding adjustment window.

The first weight is a multiplicative adjustment for the difficulty at which each block in the window was mined, relative to the difficulty of the last block in the window.  There is a theoretical basis for this that I will devote some time to explaining elsewhere.

The second weight is a simple arithmetic weight decreasing in equal steps from the most recent block in the window, down to zero for the block just prior to the window.  This is something I've been trying to do, but couldn't, until hitting on the solution of using a relative difficulty weight for the inter-block times (above).

In the current simulation this algorithm doesn't seem to display the 144-block periodicity that we see with cw-144.
