### PR TITLE
Add cw-sha-16 algorithm

### DIFF
--- a/mining.py
+++ b/mining.py
@@ -221,6 +221,19 @@ def compute_cw_target(block_count):
     work = (states[last].chainwork - states[first].chainwork) * 600 // timespan
     return (2 << 255) // work - 1
 
+def next_bits_sha(msg):
+    primes = [73, 79, 83, 89, 97,
+              101, 103, 107, 109, 113, 127,
+              131, 137, 139, 149, 151]
+
+    # The timestamp % len(primes) is a proxy for previous
+    # block SHAx2 % len(primes), but that data is not available
+    # in this simulation
+    prime = primes[states[-1].timestamp % len(primes)]
+    
+    interval_target = compute_cw_target(prime)
+    return target_to_bits(interval_target)
+
 def next_bits_cw(msg, block_count):
     interval_target = compute_cw_target(block_count)
     return target_to_bits(interval_target)
@@ -414,6 +427,7 @@ Algos = {
     'cw-144' : Algo(next_bits_cw, {
         'block_count': 144,
     }),
+    'cw-sha-16' : Algo(next_bits_sha, {}),
     'cw-180' : Algo(next_bits_cw, {
         'block_count': 180,
     }),


### PR DESCRIPTION
Add an algorithm which adjusts the windowing of the cw class of
difficulty adjustment algorithms by a random prime chosen from
a set 16 primes between [73, 151].  The random parameter is
chosen by selecting the previous block hash modulo 16.

This is to prevent oscillations.