### PR TITLE
Use suitable_block_index (sorting) in compute_cw_target

### DIFF
--- a/mining.py
+++ b/mining.py
@@ -215,7 +215,9 @@ def next_bits_d(msg):
     return target_to_bits(next_target)
 
 def compute_cw_target(block_count):
-    first, last  = -1-block_count, -1
+    N = len(states) - 1
+    last = suitable_block_index(N)
+    first = suitable_block_index(N - block_count)
     timespan = states[last].timestamp - states[first].timestamp
     timespan = max(block_count * 600 // 2, min(block_count * 2 * 600, timespan))
     work = (states[last].chainwork - states[first].chainwork) * 600 // timespan


### PR DESCRIPTION
This plugs in the the special sorting function (suitable_block_index) for use by all the cw algorithms.

Main reason for doing this is to make cw-144 equivalent to the new DAA proposed in https://github.com/Bitcoin-UAHF/spec/blob/master/nov-13-hardfork-spec.md v1.1 .

Whether the Python code matches it exactly even with this change is still TBD.